### PR TITLE
Add utf8 signifier to binary strings

### DIFF
--- a/priv/neotoma_parse.peg
+++ b/priv/neotoma_parse.peg
@@ -156,7 +156,7 @@ regexp_string <- '#' string:(!'#' ('\\#' / .))+ '#'
 	%  \ -> \\
 	%  " -> \"
    re:replace(proplists:get_value(string, Node), "\"|\\\\", "\\\\&", [{return, binary}, global]),
-   "\">>)"]
+   "\"/utf8>>)"]
 `;
 
 quoted_string <- single_quoted_string / double_quoted_string
@@ -164,7 +164,7 @@ quoted_string <- single_quoted_string / double_quoted_string
   used_combinator(p_string),
   lists:flatten(["p_string(<<\"",
    escape_string(unicode:characters_to_list(proplists:get_value(string, Node))),
-   "\">>)"])
+   "\"/utf8>>)"])
 `;
 
 double_quoted_string <- '"' string:(!'"' ("\\\\" / '\\"' / .))* '"' ~;
@@ -177,7 +177,7 @@ case_insensitive_string <- target:(double_quoted_string / single_quoted_string) 
   Str = string:lowercase(proplists:get_value(string, proplists:get_value(target, Node))),
   lists:flatten(["p_case_insensitive(<<\"", 
     escape_string(unicode:characters_to_list(Str)),
-    "\">>)"])
+    "\"/utf8>>)"])
 `;
 
 character_class <- '[' characters:(!']' ('\\\\' . / !'\\\\' .))+ ']'
@@ -185,7 +185,7 @@ character_class <- '[' characters:(!']' ('\\\\' . / !'\\\\' .))+ ']'
   used_combinator(p_charclass),
   ["p_charclass(<<\"[",
    escape_string(unicode:characters_to_list(proplists:get_value(characters, Node))),
-   "]\">>)"]
+   "]\"/utf8>>)"]
 `;
 
 anything_symbol <- '.' ` used_combinator(p_anything), <<"p_anything()">> `;

--- a/src/neotoma_parse.erl
+++ b/src/neotoma_parse.erl
@@ -306,7 +306,7 @@ end
 	%  \ -> \\
 	%  " -> \"
    re:replace(proplists:get_value(string, Node), "\"|\\\\", "\\\\&", [{return, binary}, global]),
-   "\">>)"]
+   "\"/utf8>>)"]
  end).
 
 -spec 'quoted_string'(input(), index()) -> parse_result().
@@ -315,7 +315,7 @@ end
   used_combinator(p_string),
   lists:flatten(["p_string(<<\"",
    escape_string(unicode:characters_to_list(proplists:get_value(string, Node))),
-   "\">>)"])
+   "\"/utf8>>)"])
  end).
 
 -spec 'double_quoted_string'(input(), index()) -> parse_result().
@@ -333,7 +333,7 @@ end
   Str = string:lowercase(proplists:get_value(string, proplists:get_value(target, Node))),
   lists:flatten(["p_case_insensitive(<<\"", 
     escape_string(unicode:characters_to_list(Str)),
-    "\">>)"])
+    "\"/utf8>>)"])
  end).
 
 -spec 'character_class'(input(), index()) -> parse_result().
@@ -342,7 +342,7 @@ end
   used_combinator(p_charclass),
   ["p_charclass(<<\"[",
    escape_string(unicode:characters_to_list(proplists:get_value(characters, Node))),
-   "]\">>)"]
+   "]\"/utf8>>)"]
  end).
 
 -spec 'anything_symbol'(input(), index()) -> parse_result().

--- a/test/test_parse.erl
+++ b/test/test_parse.erl
@@ -32,3 +32,18 @@ case_insensitive_test() ->
     catch
         _:_  -> ?assert(false)
     end.
+
+unicode_parser_test() ->
+    Data = "rule <- [\\x{1}-\\x{D7FF}]+;",
+    file:write_file("test_unicode_parser.peg", io_lib:fwrite("~s\n", [Data])),
+    neotoma:file("test_unicode_parser.peg"),
+    compile:file("test_unicode_parser.erl", []),
+    try
+        TestString =  [19990,30028,32,102,111,111],
+        Result = test_unicode_parser:parse(TestString),
+        ?assertEqual(6, length(Result)),
+        StringResult = lists:flatten(io_lib:format("~ts", [Result])),
+        ?assertEqual(TestString, StringResult)
+    catch
+        _:_  -> ?assert(false)
+    end.


### PR DESCRIPTION
This ensures that binary strings with UTF-8 encoded characters
(above codepoint 127) can be parsed.